### PR TITLE
Update Revel's package name for new repo

### DIFF
--- a/app/controllers/results.go
+++ b/app/controllers/results.go
@@ -3,7 +3,7 @@ package yield
 import (
 	"bytes"
 	"fmt"
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/app/controllers/yield.go
+++ b/app/controllers/yield.go
@@ -19,7 +19,7 @@ package yield
 import (
 	"bytes"
 	"fmt"
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 	htmlTmpl "html/template"
 	"path/filepath"
 	"runtime"

--- a/samples/booking/app/controllers/app.go
+++ b/samples/booking/app/controllers/app.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"code.google.com/p/go.crypto/bcrypt"
-	"github.com/robfig/revel"
-	"github.com/robfig/revel/samples/booking/app/models"
-	"github.com/robfig/revel/samples/booking/app/routes"
+	"github.com/revel/revel"
+	"github.com/revel/revel/samples/booking/app/models"
+	"github.com/revel/revel/samples/booking/app/routes"
 )
 
 type Application struct {

--- a/samples/booking/app/controllers/gorp.go
+++ b/samples/booking/app/controllers/gorp.go
@@ -6,9 +6,9 @@ import (
 	"github.com/acsellers/yield/app/controllers"
 	"github.com/coopernurse/gorp"
 	_ "github.com/mattn/go-sqlite3"
-	r "github.com/robfig/revel"
-	"github.com/robfig/revel/modules/db/app"
-	"github.com/robfig/revel/samples/booking/app/models"
+	r "github.com/revel/revel"
+	"github.com/revel/revel/modules/db/app"
+	"github.com/revel/revel/samples/booking/app/models"
 )
 
 var (

--- a/samples/booking/app/controllers/hotels.go
+++ b/samples/booking/app/controllers/hotels.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"code.google.com/p/go.crypto/bcrypt"
 	"fmt"
-	"github.com/robfig/revel"
-	"github.com/robfig/revel/samples/booking/app/models"
-	"github.com/robfig/revel/samples/booking/app/routes"
+	"github.com/revel/revel"
+	"github.com/revel/revel/samples/booking/app/models"
+	"github.com/revel/revel/samples/booking/app/routes"
 	"strings"
 )
 

--- a/samples/booking/app/controllers/init.go
+++ b/samples/booking/app/controllers/init.go
@@ -2,7 +2,7 @@ package controllers
 
 import (
 	"github.com/acsellers/yield/app/controllers"
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 )
 
 func init() {

--- a/samples/booking/app/init.go
+++ b/samples/booking/app/init.go
@@ -1,6 +1,6 @@
 package app
 
-import "github.com/robfig/revel"
+import "github.com/revel/revel"
 
 func init() {
 	// Filters is the default set of global filters.

--- a/samples/booking/app/jobs/count.go
+++ b/samples/booking/app/jobs/count.go
@@ -2,10 +2,10 @@ package jobs
 
 import (
 	"fmt"
-	"github.com/robfig/revel"
-	"github.com/robfig/revel/modules/jobs/app/jobs"
-	"github.com/robfig/revel/samples/booking/app/controllers"
-	"github.com/robfig/revel/samples/booking/app/models"
+	"github.com/revel/revel"
+	"github.com/revel/revel/modules/jobs/app/jobs"
+	"github.com/revel/revel/samples/booking/app/controllers"
+	"github.com/revel/revel/samples/booking/app/models"
 )
 
 // Periodically count the bookings in the database.

--- a/samples/booking/app/layouts/application.html
+++ b/samples/booking/app/layouts/application.html
@@ -46,7 +46,7 @@
     </div>
 
     <div id="footer">
-      Created with the <a href="http://github.com/robfig/revel">Revel framework</a> and really inspirated from the booking sample application provided by <a href="http://www.playframework.org">play framework</a>, which was really inspired by the booking sample application provided by the <a href="http://seamframework.org/">seam framework</a>.
+      Created with the <a href="http://github.com/revel/revel">Revel framework</a> and really inspirated from the booking sample application provided by <a href="http://www.playframework.org">play framework</a>, which was really inspired by the booking sample application provided by the <a href="http://seamframework.org/">seam framework</a>.
     </div>
 
   </body>

--- a/samples/booking/app/models/booking.go
+++ b/samples/booking/app/models/booking.go
@@ -3,7 +3,7 @@ package models
 import (
 	"fmt"
 	"github.com/coopernurse/gorp"
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 	"regexp"
 	"time"
 )

--- a/samples/booking/app/models/hotel.go
+++ b/samples/booking/app/models/hotel.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 )
 
 type Hotel struct {

--- a/samples/booking/app/models/user.go
+++ b/samples/booking/app/models/user.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"fmt"
-	"github.com/robfig/revel"
+	"github.com/revel/revel"
 	"regexp"
 )
 

--- a/samples/booking/conf/app.conf
+++ b/samples/booking/conf/app.conf
@@ -27,13 +27,13 @@ db.spec   = :memory:
 build.tags=gorp
 
 module.yield=github.com/acsellers/yield
-module.jobs=github.com/robfig/revel/modules/jobs
-module.static=github.com/robfig/revel/modules/static
+module.jobs=github.com/revel/revel/modules/jobs
+module.static=github.com/revel/revel/modules/static
 
 [dev]
 mode.dev=true
 watch=true
-module.testrunner=github.com/robfig/revel/modules/testrunner
+module.testrunner=github.com/revel/revel/modules/testrunner
 
 [prod]
 watch=false

--- a/samples/booking/tests/apptest.go
+++ b/samples/booking/tests/apptest.go
@@ -1,6 +1,6 @@
 package tests
 
-import "github.com/robfig/revel"
+import "github.com/revel/revel"
 
 type ApplicationTest struct {
 	revel.TestSuite


### PR DESCRIPTION
Revel has been relocated to a new GitHub repo
(https://github.com/revel/revel/). This project should import the new
repo in order to be used properly by up-to-date Revel framework.
